### PR TITLE
Prevent NullPointerException

### DIFF
--- a/src/main/java/com/gistlabs/mechanize/MechanizeAgent.java
+++ b/src/main/java/com/gistlabs/mechanize/MechanizeAgent.java
@@ -325,8 +325,10 @@ public class MechanizeAgent {
 		for(FormElement formElement : form) {
 			if(formElement instanceof Upload) {
 				Upload upload = (Upload)formElement;
-				File file = upload.hasFileValue() ? upload.getFileValue() : new File(upload.getValue());
-				request.set(upload.getName(), file);
+				if(upload.getFileValue() != null || upload.getValue() != null) {
+					File file = upload.hasFileValue() ? upload.getFileValue() : new File(upload.getValue());
+					request.set(upload.getName(), file);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
If no file should be uploaded in a multiform form it did fail with a NullPointerException, because it calls new File(null). Added a null check before.
